### PR TITLE
Adjusting push workflow to only run on branch push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - "*"
   pull_request:
     types: [opened, reopened, synchronize]
 


### PR DESCRIPTION
Using `branches` `*` filter to ensure that tags don't trigger push workflow.

