### PR TITLE
Adding `-x`/`--execution` flag to allow for `set -x` like functionality.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +162,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +225,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -223,7 +254,7 @@ version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys",
 ]
@@ -234,7 +265,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
  "windows-sys",
@@ -254,6 +285,12 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -432,6 +469,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +563,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "colored",
  "serde_derive",
  "serde_yaml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.70"
 clap = { version = "4.2.2", features = ["derive"] }
+colored = { version = "2.0.0" }
 serde_derive = "1.0.160"
 serde_yaml = "0.9.21"
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Options:
   -c, --config <CONFIG>  The config file to use
   -p, --print            Print the config file before running the command
       --sd <SD>          Search and displacements to make in the command before running it. Expects a key and value separated by an `=`. e.g. `--sd key=value`
+  -x, --execute          Print the command that will be executed before executing it
   -h, --help             Print help
   -V, --version          Print version
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,14 @@ struct Args {
     #[arg(long)]
     sd: Vec<String>,
 
+    /// Print the command that will be executed before executing it.
+    #[arg(short = 'x', long, default_value_t = false)]
+    execution: bool,
+
+    /// Don't add color to anything printed to stdout by ya.
+    #[arg(long, default_value_t = false)]
+    no_color: bool,
+
     /// The command in the config to use.
     #[arg()]
     command: Option<String>,
@@ -61,6 +69,8 @@ fn main() -> anyhow::Result<()> {
             command_name,
             args.sd.as_slice(),
             args.quiet,
+            args.execution,
+            args.no_color,
             args.extra_args.as_slice(),
         )?
     }

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -1,0 +1,19 @@
+#[cfg(test)]
+mod basic {
+    use anyhow::Result;
+    use assert_cmd::Command;
+    fn ya() -> Command {
+        Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Error invoking ya")
+    }
+
+    #[test]
+    fn basic() -> Result<()> {
+        ya().args(["-x", "run"])
+            .current_dir("examples/basic")
+            .assert()
+            .success()
+            .stdout("$ bash -c \'echo \"Hey ya!\"\'\nHey ya!\n");
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adjusted the struct used for parsed configurations so that the command that is run implements `std::fmt::Display`. This allows for better error messages when things go wrong, and for a a flag to be sent to activate `set -x` like functionality to print commands as they are run.