### PR TITLE
Allow for ya configs in git root and home

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "home"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +573,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "colored",
+ "home",
  "serde_derive",
  "serde_yaml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 anyhow = "1.0.70"
 clap = { version = "4.2.2", features = ["derive"] }
 colored = { version = "2.0.0" }
+home = "0.5.4"
 serde_derive = "1.0.160"
 serde_yaml = "0.9.21"
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -35,8 +35,18 @@ Ya will look for a config file in the following locations, in order:
 - `./ya.yaml`
 - `./.config/ya.yml`
 - `./.config/ya.yaml`
+- `$GIT_ROOT/ya.yml`
+- `$GIT_ROOT/ya.yaml`
+- `$GIT_ROOT/.config/ya.yml`
+- `$GIT_ROOT/.config/ya.yaml`
+- `$HOME/ya.yml`
+- `$HOME/ya.yaml`
+- `$HOME/.config/ya.yml`
+- `$HOME/.config/ya.yaml`
 
-Note that although you the highest precedence config file is the one in the current directory, I recommend tucking your config file into the `.config` directory. This reduces clutter in your configurations and allows you to quickly override the config file by creating a temporary config in the current directory.
+Where `$GIT_ROOT` is the root of the git repository that the current directory is in, and `$HOME` is the home directory of the current user.
+
+Note that although you the highest precedence config file is the one in the current directory, I recommend tucking your config file into the `.config` directory for repository configurations. This reduces clutter in your configurations and allows you to quickly override the config file by creating a temporary config in the current directory.
 
 You can also specify a config file to use explicitly with the `-c`/`--config` flag.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -31,10 +31,12 @@ command_as_mapping:
 
 Ya will look for a config file in the following locations, in order:
 
-- `./.config/ya.yml`
-- `./.config/ya.yaml`
 - `./ya.yml`
 - `./ya.yaml`
+- `./.config/ya.yml`
+- `./.config/ya.yaml`
+
+Note that although you the highest precedence config file is the one in the current directory, I recommend tucking your config file into the `.config` directory. This reduces clutter in your configurations and allows you to quickly override the config file by creating a temporary config in the current directory.
 
 You can also specify a config file to use explicitly with the `-c`/`--config` flag.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::io::BufReader;
 use std::path::Path;
 use std::path::PathBuf;
 
-const DEFAULT_CONFIG_PATHS: [&str; 4] = [".config/ya.yml", ".config/ya.yaml", "ya.yml", "ya.yaml"];
+const DEFAULT_CONFIG_PATHS: [&str; 4] = ["ya.yml", "ya.yaml", ".config/ya.yml", ".config/ya.yaml"];
 
 pub fn get_config_path(path: &Option<PathBuf>) -> anyhow::Result<PathBuf> {
     let path = match path {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,9 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 use std::path::PathBuf;
+use home::home_dir;
+
+use crate::git::get_git_root;
 
 const DEFAULT_CONFIG_PATHS: [&str; 4] = ["ya.yml", "ya.yaml", ".config/ya.yml", ".config/ya.yaml"];
 
@@ -14,6 +17,26 @@ pub fn get_config_path(path: &Option<PathBuf>) -> anyhow::Result<PathBuf> {
                 let path = Path::new(config_path);
                 if path.exists() && path.is_file() {
                     return Ok(path.to_path_buf());
+                }
+            }
+
+            let git_root = get_git_root();
+            if let Ok(git_root) = git_root {
+                for config_path in DEFAULT_CONFIG_PATHS.iter() {
+                    let path = Path::new(&git_root).join(config_path);
+                    if path.exists() && path.is_file() {
+                        return Ok(path);
+                    }
+                }
+            }
+
+            let home = home_dir();
+            if let Some(home) = home {
+                for config_path in DEFAULT_CONFIG_PATHS.iter() {
+                    let path = Path::new(&home).join(config_path);
+                    if path.exists() && path.is_file() {
+                        return Ok(path);
+                    }
                 }
             }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,10 @@
+use std::{process::Command};
+
+pub fn get_git_root() -> anyhow::Result<String> {
+    let output = Command::new("git")
+        .arg("rev-parse")
+        .arg("--show-toplevel")
+        .output()?;
+    let root = String::from_utf8(output.stdout)?;
+    Ok(root)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 mod cmd;
 mod config;
 mod validate;
+mod git;
 
 use cmd::run_command_from_config;
 use config::{parse_config_from_file, print_config_from_file, get_config_path};


### PR DESCRIPTION
- Changing order precedence so that local `ya.yml` takes higher precedence than `.config/ya.yml`
- Allowing for ya configs to be discovered in git root and home directory
