### PR TITLE
Adding `chdir` to config schema to allow for directory changes before running commands

### DIFF
--- a/.config/ya.yml
+++ b/.config/ya.yml
@@ -1,6 +1,7 @@
 install:
   prog: cargo
   args: ["install", "--path", "."]
+  chdir: $GIT_ROOT
 
 lint:
   prog: cargo

--- a/docs/config.md
+++ b/docs/config.md
@@ -15,6 +15,8 @@ command_as_mapping:
 
   pre_msg: Optional String
   post_msg: Optional String
+
+  chdir: Optional String
 ```
 
 - `command_as_string` is a string that will be run as a command. This is equivalent to `command_as_mapping` with `prog` set to `bash`, `args` set to `-c` and `cmd` set to the value.
@@ -26,6 +28,7 @@ command_as_mapping:
   - `post_cmds` is a list of commands found in the config to run after the command.
   - `pre_msg` is a message to print before running the command.
   - `post_msg` is a message to print after running the command.
+  - `chdir` is the directory to change to before running the command.
 
 ## Config File Precedence
 
@@ -158,3 +161,16 @@ Note that you can use the `-q`/`quiet` flag to suppress the output of `pre_msg` 
 ❯ ya -q test_difficult_stuff
 Testing difficult stuff...
 ```
+
+### Chdir
+
+Using the `chdir` key, you can specify a directory to change to before running the command. For example, you might want to always run your tests from the root of your repository. You can do that like so:
+
+```yml
+install:
+  prog: cargo
+  args: ["install", "--path", "."]
+  chdir: $GIT_ROOT
+```
+
+You can also use a `chdir` key that starts with the `$HOME` variable to change to a path relative to your home directory, or use local a relative path.

--- a/examples/chdir/.config/ya.yml
+++ b/examples/chdir/.config/ya.yml
@@ -1,0 +1,25 @@
+local: cat test.txt
+
+dir1:
+  cmd: cat test.txt
+  chdir: dir1
+
+dir2:
+  cmd: cat test.txt
+  chdir: dir2
+
+home:
+  cmd: |
+    if [ -f ~/test.txt ]; then
+      echo 'Will not edit file.txt in your home directory as part of this test. Please delete it, then run the test again.'
+      exit 1
+    fi
+
+    echo 'Home directory' > ~/test.txt
+    cat test.txt
+    rm -f ~/test.txt
+  chdir: $HOME
+
+git:
+  cmd: cat test.txt
+  chdir: $GIT_ROOT/examples/chdir/git

--- a/examples/chdir/dir1/test.txt
+++ b/examples/chdir/dir1/test.txt
@@ -1,0 +1,1 @@
+Directory one

--- a/examples/chdir/dir2/test.txt
+++ b/examples/chdir/dir2/test.txt
@@ -1,0 +1,1 @@
+Directory two

--- a/examples/chdir/git/test.txt
+++ b/examples/chdir/git/test.txt
@@ -1,0 +1,1 @@
+Directory relative to git root

--- a/examples/chdir/test.txt
+++ b/examples/chdir/test.txt
@@ -1,0 +1,1 @@
+Base directory

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,8 +1,8 @@
-use serde_yaml::Value;
-use std::{process::Command};
 use colored::Colorize;
+use serde_yaml::Value;
+use std::process::Command;
 
-use crate::config::{parse_cmd, ParsedConfig, ParsedCommand};
+use crate::config::{parse_cmd, resolve_chdir, ParsedCommand, ParsedConfig};
 
 pub fn run_command_from_config(
     config: &Value,
@@ -38,6 +38,7 @@ fn run_command(
         post_msg,
         pre_cmds,
         post_cmds,
+        chdir,
     } = command;
 
     let ParsedCommand {
@@ -62,7 +63,7 @@ fn run_command(
 
     if execution {
         let mut parsed_command = format!("$ {}", parsed_command);
-        if ! no_color {
+        if !no_color {
             parsed_command = parsed_command.blue().bold().to_string();
         }
         println!("{}", parsed_command);
@@ -81,6 +82,11 @@ fn run_command(
     }
 
     command_builder.args(extra_args);
+
+    if let Some(chdir) = chdir {
+        let chdir = resolve_chdir(chdir)?;
+        command_builder.current_dir(chdir);
+    }
 
     let result = command_builder.spawn()?.wait()?;
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,10 +1,10 @@
-use std::{process::Command};
+use std::process::Command;
 
 pub fn get_git_root() -> anyhow::Result<String> {
     let output = Command::new("git")
         .arg("rev-parse")
         .arg("--show-toplevel")
         .output()?;
-    let root = String::from_utf8(output.stdout)?;
+    let root = String::from_utf8(output.stdout)?.trim().to_string();
     Ok(root)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,11 @@ use std::path::PathBuf;
 
 mod cmd;
 mod config;
-mod validate;
 mod git;
+mod validate;
 
 use cmd::run_command_from_config;
-use config::{parse_config_from_file, print_config_from_file, get_config_path};
+use config::{get_config_path, parse_config_from_file, print_config_from_file};
 use validate::{validate_config_file, validate_sd};
 
 /// Automation tool for lazy people.

--- a/tests/chdir.rs
+++ b/tests/chdir.rs
@@ -1,0 +1,59 @@
+#[cfg(test)]
+mod chdir {
+    use anyhow::Result;
+    use assert_cmd::Command;
+    fn ya() -> Command {
+        Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Error invoking ya")
+    }
+
+    #[test]
+    fn chdir_noop() -> Result<()> {
+        ya().args(["local"])
+            .current_dir("examples/chdir")
+            .assert()
+            .success()
+            .stdout("Base directory\n");
+
+        Ok(())
+    }
+    #[test]
+    fn chdir_dir1() -> Result<()> {
+        ya().args(["dir1"])
+            .current_dir("examples/chdir")
+            .assert()
+            .success()
+            .stdout("Directory one\n");
+
+        Ok(())
+    }
+    #[test]
+    fn chdir_dir2() -> Result<()> {
+        ya().args(["dir2"])
+            .current_dir("examples/chdir")
+            .assert()
+            .success()
+            .stdout("Directory two\n");
+
+        Ok(())
+    }
+    #[test]
+    fn chdir_home() -> Result<()> {
+        ya().args(["home"])
+            .current_dir("examples/chdir")
+            .assert()
+            .success()
+            .stdout("Home directory\n");
+
+        Ok(())
+    }
+    #[test]
+    fn chdir_git() -> Result<()> {
+        ya().args(["git"])
+            .current_dir("examples/chdir")
+            .assert()
+            .success()
+            .stdout("Directory relative to git root\n");
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adding the `chdir` key to the config schema to allow for commands to be run in directories other than the current one.

`chdir` values that start with `$GIT_ROOT` or `$HOME` will be relative to the git root or the home directory.

