### PR TITLE
Fixing Extra Args

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -129,8 +129,20 @@ fn run_command(
         }
     }
 
+    let mut final_args = args.clone().to_vec();
+
+    if let Some(cmd) = cmd {
+        let cmd = run_command_flags.sd.iter().fold(cmd, |cmd, s| {
+            let (key, value) = s.split_once('=').unwrap();
+            cmd.replace(key, value)
+        });
+        final_args.push(cmd);
+    }
+
+    final_args.extend_from_slice(extra_args);
+
     if run_command_flags.execution {
-        let mut parsed_command = format!("$ {}", full_command);
+        let mut parsed_command = format!("$ {} {}", prog, final_args.join(" "));
         if !run_command_flags.no_color {
             parsed_command = parsed_command.blue().bold().to_string();
         }
@@ -139,17 +151,7 @@ fn run_command(
 
     let mut command_builder = Command::new(prog);
 
-    command_builder.args(args);
-
-    if let Some(cmd) = cmd {
-        let cmd = run_command_flags.sd.iter().fold(cmd, |cmd, s| {
-            let (key, value) = s.split_once('=').unwrap();
-            cmd.replace(key, value)
-        });
-        command_builder.arg(cmd);
-    }
-
-    command_builder.args(extra_args);
+    command_builder.args(final_args);
 
     if let Some(chdir) = chdir {
         let chdir = resolve_chdir(chdir)?;

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -12,7 +12,7 @@ mod basic {
             .current_dir("examples/basic")
             .assert()
             .success()
-            .stdout("$ bash -c \'echo \"Hey ya!\"\'\nHey ya!\n");
+            .stdout("$ bash -c echo \"Hey ya!\"\nHey ya!\n");
 
         Ok(())
     }


### PR DESCRIPTION
# Summary

Was running into issues with how `extra_args` was being pulled in on the CLI before making this adjustment.

This makes it so that all arguments being passed to `prog` are collected into an intermediate vector before being printed with `-x` or being run.

# Changes

- Using a secondary vector to collect all the args before adding them to the command builder
- Updating test now that we're not adding single quotes to the `cmd` value
