### PR TITLE
Adding default passthrough of config

### DIFF
--- a/.config/ya/tag.yml
+++ b/.config/ya/tag.yml
@@ -3,18 +3,23 @@ ensure_sd: |
     cargo install --locked sd
   fi
 
-ensure_rg: |
-  if ! command -v rg >/dev/null; then
-    cargo install --locked ripgrep
-  fi
+commit_update: |
+  set -euo pipefail
+
+  new_version="${0:?missing required positional parameter 'new_version'}"
+
+  git add Cargo.toml Cargo.lock
+  git commit -m "Bump version to $new_version"
+  git tag -a "$new_version" -m "Tag $new_version"
+  git push --follow-tags
+
 
 release_patch:
   chdir: $GIT_ROOT
   cmd: |
     set -euo pipefail
 
-    ya -c .config/ya/tag.yml ensure_sd
-    ya -c .config/ya/tag.yml ensure_rg
+    ya ensure_sd
 
     version=$(cargo pkgid | sd '^.*#([^ ]+)$' '$1')
     major=$(echo "$version" | sd '^([0-9]+)\.[0-9]+\.[0-9]+$' '$1')
@@ -25,18 +30,14 @@ release_patch:
     sd '^version = "[0-9]+\.[0-9]+\.[0-9]+"$' "version = \"$new_version\"" Cargo.toml
     cargo update
 
-    git add Cargo.toml Cargo.lock
-    git commit -m "Bump version to $new_version"
-    git tag -a "$new_version" -m "Tag $new_version"
-    git push --follow-tags
+    ya commit_update "$new_version"
 
 release_minor:
   chdir: $GIT_ROOT
   cmd: |
     set -euo pipefail
 
-    ya -c .config/ya/tag.yml ensure_sd
-    ya -c .config/ya/tag.yml ensure_rg
+    ya ensure_sd
 
     version=$(cargo pkgid | sd '^.*#([^ ]+)$' '$1')
     major=$(echo "$version" | sd '^([0-9]+)\.[0-9]+\.[0-9]+$' '$1')
@@ -47,18 +48,14 @@ release_minor:
     sd '^version = "[0-9]+\.[0-9]+\.[0-9]+"$' "version = \"$new_version\"" Cargo.toml
     cargo update
 
-    git add Cargo.toml Cargo.lock
-    git commit -m "Bump version to $new_version"
-    git tag -a "$new_version" -m "Tag $new_version"
-    git push --follow-tags
+    ya commit_update "$new_version"
 
 release_major:
   chdir: $GIT_ROOT
   cmd: |
     set -euo pipefail
 
-    ya -c .config/ya/tag.yml ensure_sd
-    ya -c .config/ya/tag.yml ensure_rg
+    ya ensure_sd
 
     version=$(cargo pkgid | sd '^.*#([^ ]+)$' '$1')
     major=$(echo "$version" | sd '^([0-9]+)\.[0-9]+\.[0-9]+$' '$1')
@@ -69,7 +66,4 @@ release_major:
     sd '^version = "[0-9]+\.[0-9]+\.[0-9]+"$' "version = \"$new_version\"" Cargo.toml
     cargo update
 
-    git add Cargo.toml Cargo.lock
-    git commit -m "Bump version to $new_version"
-    git tag -a "$new_version" -m "Tag $new_version"
-    git push --follow-tags
+    ya commit_update "$new_version"

--- a/docs/config.md
+++ b/docs/config.md
@@ -72,7 +72,9 @@ Where `$GIT_ROOT` is the root of the git repository that the current directory i
 
 Note that although the highest precedence config file is the one in the current directory, I recommend tucking your config file into a `.config` directory when you can. This reduces clutter in your repo and allows you to quickly override the config file by creating a temporary config in the current directory.
 
-You can also explicitly specify a config file with the `-c`/`--config` flag.
+You can also explicitly specify a config file with the `-c`/`--config` flag or by setting the `YA_CONFIG` environment variable with the path to the config file. Note that if both are set, the flag will take precedence.
+
+Note that the `YA_CONFIG` is used to simplify the process of discovering config files when calling `ya` recursively. For example, if you have a config file in a non-default location, and use `-c` to specify it, the default behavior of `ya` will be to re-use that config file.
 
 ## Building a Config
 

--- a/examples/from/chained/.config/ya.yml
+++ b/examples/from/chained/.config/ya.yml
@@ -1,0 +1,2 @@
+call: ya -c .config/ya/chained.yml run
+

--- a/examples/from/chained/.config/ya/chained.yml
+++ b/examples/from/chained/.config/ya/chained.yml
@@ -1,0 +1,2 @@
+done: echo Done
+run: ya done

--- a/examples/named/.config/ya/named.yml
+++ b/examples/named/.config/ya/named.yml
@@ -1,0 +1,6 @@
+run: |
+  echo "Running the test."
+  ya test
+
+test: |
+  echo "Test passed."

--- a/src/bin/ya.rs
+++ b/src/bin/ya.rs
@@ -30,6 +30,7 @@ fn main() -> anyhow::Result<()> {
             &RunCommandFlags {
                 execution: args.execution,
                 quiet: args.quiet,
+                config: config_path,
             },
             args.extra_args.as_slice(),
         )?

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,17 @@ pub fn get_config_path(path: &Option<PathBuf>) -> anyhow::Result<PathBuf> {
     let path = match path {
         Some(path) => path,
         None => {
+            if let Some(ya_config) = std::env::var_os("YA_CONFIG") {
+                let ya_config_path = Path::new(&ya_config);
+                if ya_config_path.exists() && ya_config_path.is_file() {
+                    return Ok(ya_config_path.to_path_buf());
+                }
+                return Err(anyhow::anyhow!(
+                    "Could not find config file in $YA_CONFIG: {}",
+                    ya_config.to_string_lossy()
+                ));
+            }
+
             for config_location in DEFAULT_CONFIG_LOCATIONS.iter() {
                 let config_location = if config_location.starts_with("$GIT_ROOT") {
                     let git_root = get_git_root().unwrap_or(".".to_string());

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -47,7 +47,9 @@ mod from {
         Ok(())
     }
 
+    /// This test is ignored by default because it requires an installed `ya` binary to be accessible in PATH.
     #[test]
+    #[ignore]
     fn chained() -> Result<()> {
         ya().args(["call"])
             .current_dir("examples/from/chained")

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -46,4 +46,15 @@ mod from {
 
         Ok(())
     }
+
+    #[test]
+    fn chained() -> Result<()> {
+        ya().args(["call"])
+            .current_dir("examples/from/chained")
+            .assert()
+            .success()
+            .stdout("Done\n");
+
+        Ok(())
+    }
 }

--- a/tests/named.rs
+++ b/tests/named.rs
@@ -6,7 +6,9 @@ mod named {
         Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Error invoking ya")
     }
 
+    /// This test is ignored by default because it requires an installed `ya` binary to be accessible in PATH.
     #[test]
+    #[ignore]
     fn named() -> Result<()> {
         ya().args([ "-c", ".config/ya/named.yml", "run"])
             .current_dir("examples/named")

--- a/tests/named.rs
+++ b/tests/named.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod top_level {
+mod named {
     use anyhow::Result;
     use assert_cmd::Command;
     fn ya() -> Command {
@@ -7,13 +7,12 @@ mod top_level {
     }
 
     #[test]
-    fn top_level() -> Result<()> {
-        ya().args(["run"])
-            .env_clear()
-            .current_dir("examples/top-level")
+    fn named() -> Result<()> {
+        ya().args([ "-c", ".config/ya/named.yml", "run"])
+            .current_dir("examples/named")
             .assert()
             .success()
-            .stdout("This file is not in a .config directory!\n");
+            .stdout("Running the test.\nTest passed.\n");
 
         Ok(())
     }


### PR DESCRIPTION
Sets the `ya` config to the same value of the currently used config when calling `ya` recursively.

Makes it so that the `-c` flag doesn't have to be set repeatedly when used in a custom location.